### PR TITLE
[4.x] Add Experimental Herd Valet support

### DIFF
--- a/bin/server.php
+++ b/bin/server.php
@@ -1,8 +1,12 @@
 <?php
 
 try {
-    define('BASE_PATH', realpath(getcwd()));
+    define('BASE_PATH', isset($_SERVER['HERD_SITE_PATH']) ? realpath($_SERVER['HERD_SITE_PATH']) : realpath(getcwd()));
     define('HYDE_START', microtime(true));
+
+    if (isset($_SERVER['HERD_SITE_PATH'])) {
+        chdir($_SERVER['HERD_SITE_PATH']);
+    }
 
     require getenv('HYDE_AUTOLOAD_PATH') ?: BASE_PATH.'/vendor/autoload.php';
 

--- a/resources/stubs/HydeValetDriver.php
+++ b/resources/stubs/HydeValetDriver.php
@@ -5,6 +5,10 @@ namespace Valet\Drivers\Custom;
 use Composer\InstalledVersions;
 use Valet\Drivers\BasicValetDriver;
 
+/**
+ * @experimental This driver is experimental and may be unstable. Report issues at GitHub!
+ * @see https://github.com/hydephp/realtime-compiler/pull/30
+ */
 class HydeValetDriver extends BasicValetDriver
 {
     /**
@@ -16,15 +20,20 @@ class HydeValetDriver extends BasicValetDriver
     }
 
     /**
+     * Take any steps necessary before loading the front controller for this driver.
+     */
+    public function beforeLoading(string $sitePath, string $siteName, string $uri): void
+    {
+        // Set the correct autoloader path for the realtime compiler
+        putenv('HYDE_AUTOLOAD_PATH='.$sitePath.'/vendor/autoload.php');
+    }
+
+    /**
      * Determine if the incoming request is for a static file.
      */
     public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
-        if (file_exists($staticFilePath = $sitePath.'/_site'.$uri)) {
-            return $staticFilePath;
-        }
-
-        return false;
+        return false; // Handled by the realtime compiler
     }
 
     /**

--- a/resources/stubs/HydeValetDriver.php
+++ b/resources/stubs/HydeValetDriver.php
@@ -7,6 +7,7 @@ use Valet\Drivers\BasicValetDriver;
 
 /**
  * @experimental This driver is experimental and may be unstable. Report issues at GitHub!
+ *
  * @see https://github.com/hydephp/realtime-compiler/pull/30
  */
 class HydeValetDriver extends BasicValetDriver
@@ -31,7 +32,7 @@ class HydeValetDriver extends BasicValetDriver
     /**
      * Determine if the incoming request is for a static file.
      */
-    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
+    public function isStaticFile(string $sitePath, string $siteName, string $uri): false
     {
         return false; // Handled by the realtime compiler
     }
@@ -49,7 +50,7 @@ class HydeValetDriver extends BasicValetDriver
      */
     public function logFilesPaths(): array
     {
-        return ["/storage/logs"];
+        return ['/storage/logs'];
     }
 
     /**
@@ -57,35 +58,35 @@ class HydeValetDriver extends BasicValetDriver
      */
     public function siteInformation(string $sitePath, string $phpBinary): array
     {
-        $composerJson = json_decode(file_get_contents($sitePath . '/composer.json'), true);
-        $hydeConfig = include $sitePath . '/config/hyde.php';
+        $composerJson = json_decode(file_get_contents($sitePath.'/composer.json'), true);
+        $hydeConfig = include $sitePath.'/config/hyde.php';
 
         return [
-            "HydePHP Info" => [
-                "Hyde Version" => InstalledVersions::isInstalled('hyde/hyde') ? InstalledVersions::getPrettyVersion('hyde/hyde') : 'Unknown',
-                "Framework Version" => InstalledVersions::getPrettyVersion('hyde/framework') ?: 'Unknown',
-                "Site Name" => $hydeConfig['name'] ?? 'Unknown',
-                "Site URL" => $hydeConfig['url'] ?? 'Not set',
-                "Site Language" => $hydeConfig['language'] ?? 'en',
-                "Output Directory" => $hydeConfig['output_directory'] ?? '_site',
+            'HydePHP Info' => [
+                'Hyde Version' => InstalledVersions::isInstalled('hyde/hyde') ? InstalledVersions::getPrettyVersion('hyde/hyde') : 'Unknown',
+                'Framework Version' => InstalledVersions::getPrettyVersion('hyde/framework') ?: 'Unknown',
+                'Site Name' => $hydeConfig['name'] ?? 'Unknown',
+                'Site URL' => $hydeConfig['url'] ?? 'Not set',
+                'Site Language' => $hydeConfig['language'] ?? 'en',
+                'Output Directory' => $hydeConfig['output_directory'] ?? '_site',
             ],
-            "Build Info" => [
-                "Pretty URLs" => $hydeConfig['pretty_urls'] ? 'Enabled' : 'Disabled',
-                "Generate Sitemap" => $hydeConfig['generate_sitemap'] ? 'Yes' : 'No',
-                "RSS Feed" => ($hydeConfig['rss']['enabled'] ?? false) ? 'Enabled' : 'Disabled',
-                "Source Root" => $hydeConfig['source_root'] ?: '(Project Root)',
+            'Build Info' => [
+                'Pretty URLs' => $hydeConfig['pretty_urls'] ? 'Enabled' : 'Disabled',
+                'Generate Sitemap' => $hydeConfig['generate_sitemap'] ? 'Yes' : 'No',
+                'RSS Feed' => ($hydeConfig['rss']['enabled'] ?? false) ? 'Enabled' : 'Disabled',
+                'Source Root' => $hydeConfig['source_root'] ?: '(Project Root)',
             ],
-            "Features" => [
-                "Enabled Features" => implode(', ', array_map(function($feature) {
+            'Features' => [
+                'Enabled Features' => implode(', ', array_map(function ($feature) {
                     return $feature->name;
                 }, $hydeConfig['features'] ?? [])),
             ],
-            "Server Configuration" => [
-                "Port" => $hydeConfig['server']['port'] ?? 8080,
-                "Host" => $hydeConfig['server']['host'] ?? 'localhost',
-                "Save Preview" => ($hydeConfig['server']['save_preview'] ?? true) ? 'Yes' : 'No',
-                "Live Edit" => ($hydeConfig['server']['live_edit'] ?? false) ? 'Enabled' : 'Disabled',
-                "Dashboard" => ($hydeConfig['server']['dashboard']['enabled'] ?? true) ? 'Enabled' : 'Disabled',
+            'Server Configuration' => [
+                'Port' => $hydeConfig['server']['port'] ?? 8080,
+                'Host' => $hydeConfig['server']['host'] ?? 'localhost',
+                'Save Preview' => ($hydeConfig['server']['save_preview'] ?? true) ? 'Yes' : 'No',
+                'Live Edit' => ($hydeConfig['server']['live_edit'] ?? false) ? 'Enabled' : 'Disabled',
+                'Dashboard' => ($hydeConfig['server']['dashboard']['enabled'] ?? true) ? 'Enabled' : 'Disabled',
             ],
         ];
     }

--- a/resources/stubs/HydeValetDriver.php
+++ b/resources/stubs/HydeValetDriver.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Valet\Drivers\Custom;
+
+use Composer\InstalledVersions;
+use Valet\Drivers\BasicValetDriver;
+
+class HydeValetDriver extends BasicValetDriver
+{
+    /**
+     * Determine if the driver serves the request.
+     */
+    public function serves(string $sitePath, string $siteName, string $uri): bool
+    {
+        return file_exists($sitePath.'/hyde');
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     */
+    public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
+    {
+        if (file_exists($staticFilePath = $sitePath.'/_site'.$uri)) {
+            return $staticFilePath;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     */
+    public function frontControllerPath(string $sitePath, string $siteName, string $uri): ?string
+    {
+        return $sitePath.'/vendor/hyde/realtime-compiler/bin/server.php';
+    }
+
+    /**
+     * Get the logs paths for the application to show in Herds log viewer.
+     */
+    public function logFilesPaths(): array
+    {
+        return ["/storage/logs"];
+    }
+
+    /**
+     * Display information about the application in the information tab of the Sites UI.
+     */
+    public function siteInformation(string $sitePath, string $phpBinary): array
+    {
+        $composerJson = json_decode(file_get_contents($sitePath . '/composer.json'), true);
+        $hydeConfig = include $sitePath . '/config/hyde.php';
+
+        return [
+            "HydePHP Info" => [
+                "Hyde Version" => InstalledVersions::isInstalled('hyde/hyde') ? InstalledVersions::getPrettyVersion('hyde/hyde') : 'Unknown',
+                "Framework Version" => InstalledVersions::getPrettyVersion('hyde/framework') ?: 'Unknown',
+                "Site Name" => $hydeConfig['name'] ?? 'Unknown',
+                "Site URL" => $hydeConfig['url'] ?? 'Not set',
+                "Site Language" => $hydeConfig['language'] ?? 'en',
+                "Output Directory" => $hydeConfig['output_directory'] ?? '_site',
+            ],
+            "Build Info" => [
+                "Pretty URLs" => $hydeConfig['pretty_urls'] ? 'Enabled' : 'Disabled',
+                "Generate Sitemap" => $hydeConfig['generate_sitemap'] ? 'Yes' : 'No',
+                "RSS Feed" => ($hydeConfig['rss']['enabled'] ?? false) ? 'Enabled' : 'Disabled',
+                "Source Root" => $hydeConfig['source_root'] ?: '(Project Root)',
+            ],
+            "Features" => [
+                "Enabled Features" => implode(', ', array_map(function($feature) {
+                    return $feature->name;
+                }, $hydeConfig['features'] ?? [])),
+            ],
+            "Server Configuration" => [
+                "Port" => $hydeConfig['server']['port'] ?? 8080,
+                "Host" => $hydeConfig['server']['host'] ?? 'localhost',
+                "Save Preview" => ($hydeConfig['server']['save_preview'] ?? true) ? 'Yes' : 'No',
+                "Live Edit" => ($hydeConfig['server']['live_edit'] ?? false) ? 'Enabled' : 'Disabled',
+                "Dashboard" => ($hydeConfig['server']['dashboard']['enabled'] ?? true) ? 'Enabled' : 'Disabled',
+            ],
+        ];
+    }
+}

--- a/src/Console/Commands/HerdInstallCommand.php
+++ b/src/Console/Commands/HerdInstallCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyde\RealtimeCompiler\Console\Commands;
+
+use Hyde\Hyde;
+use Hyde\Console\Concerns\Command;
+use Illuminate\Support\Facades\File;
+use Exception;
+
+/**
+ * @experimental This command is experimental and may be unstable. Report issues at GitHub!
+ *
+ * @see https://github.com/hydephp/realtime-compiler/pull/30
+ */
+class HerdInstallCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'herd:install {--force : Overwrite any existing file}';
+
+    /** @var string */
+    protected $description = '[Experimental] Install the HydePHP Valet driver for Laravel Herd';
+
+    public function safeHandle(): int
+    {
+        $driverTargetPath = $this->getDriverTargetPath();
+        $driverSourcePath = Hyde::vendorPath('resources/stubs/HydeValetDriver.php', 'realtime-compiler');
+
+        if (! is_dir(dirname($driverTargetPath))) {
+            $this->error('Herd Valet drivers directory not found. Is Herd installed?');
+
+            return Command::FAILURE;
+        }
+
+        if (file_exists($driverTargetPath) && ! $this->option('force')) {
+            if (! $this->confirm('The HydePHP Valet driver for Herd already exists. Do you want to overwrite it?', true)) {
+                $this->info('Installation cancelled.');
+
+                return Command::SUCCESS;
+            }
+        }
+
+        try {
+            File::copy($driverSourcePath, $driverTargetPath);
+            $this->info('HydePHP Valet driver for Herd successfully installed!');
+            $this->line('Driver path: '.$driverTargetPath);
+
+            return Command::SUCCESS;
+        } catch (Exception $exception) {
+            $this->error('Failed to install the HydePHP Valet driver: '.$exception->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function getDriverTargetPath(): string
+    {
+        return match (PHP_OS_FAMILY) {
+            'Darwin' => $_SERVER['HOME'].'/Library/Application Support/Herd/config/valet/Drivers/HydeValetDriver.php',
+            'Windows' => $_SERVER['USERPROFILE'].'\.config\herd\config\valet\Drivers\HydeValetDriver.php',
+            default => throw new Exception('Herd is not yet supported on Linux.'),
+        };
+    }
+}

--- a/src/RealtimeCompilerServiceProvider.php
+++ b/src/RealtimeCompilerServiceProvider.php
@@ -5,15 +5,22 @@ declare(strict_types=1);
 namespace Hyde\RealtimeCompiler;
 
 use Illuminate\Support\ServiceProvider;
-use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\DashboardController;
+use Hyde\RealtimeCompiler\Http\LiveEditController;
 use Hyde\RealtimeCompiler\Http\VirtualRouteController;
+use Hyde\RealtimeCompiler\Console\Commands\HerdInstallCommand;
 
 class RealtimeCompilerServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
         $this->app->singleton(RealtimeCompiler::class);
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                HerdInstallCommand::class,
+            ]);
+        }
     }
 
     public function boot(): void


### PR DESCRIPTION
https://herd.laravel.com/docs/1/extending-herd/custom-drivers

Hopefully we can get this added to https://herd.laravel.com/docs/1/extending-herd/supported-frameworks

Also would be great to use data from https://github.com/hydephp/hyde/issues/293

We could potentially add a command to install the Valet driver stub to Herd

The driver must be saved to `~/Library/Application\ Support/Herd/config/valet/Drivers`